### PR TITLE
rpm/make-package: Don't exclude versioned directories from RPM ownership

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,6 @@
+Version 0.8.3
+  * rpm/make-package: Don't exclude versioned directories from RPM ownership.
+
 Version 0.8.2
   * Fix parsing of dependency versions that contain extra whitespace
     inside parens or square brackets.

--- a/fw-pkgin/config
+++ b/fw-pkgin/config
@@ -2,7 +2,7 @@
 # environment variable FW_PACKAGE_DEFAULT_MAINTAINER if non-empty
 
 FW_PACKAGE_NAME="framewerk"
-FW_PACKAGE_VERSION="0.8.2"
+FW_PACKAGE_VERSION="0.8.3"
 FW_PACKAGE_MAINTAINER="Paul Mineiro <paul-fw@mineiro.com>"
 FW_PACKAGE_SHORT_DESCRIPTION="A extensible development environment."
 FW_PACKAGE_DESCRIPTION=`cat README`

--- a/fw/package/rpm/make-package
+++ b/fw/package/rpm/make-package
@@ -271,14 +271,19 @@ EOD
               print $s;' "$destdir" >> "$destdir"/_TMP/package.spec
 
     find "$destdir" -type d | \
-    perl -lne 'BEGIN { $l = length shift @ARGV; };
-               chomp;
-               $s = substr ($_, $l);
+    perl -Mstrict -Mwarnings \
+         -e 'my ($basedir, $ver) = @ARGV;
+             my $baselen = length($basedir);
+             while (<STDIN>) {
+               chomp($_);
+               my $s = substr($_, $baselen);
                next unless $s =~ /\S/;
                next if $s =~ m%^/?_TMP%;
                next if -l $s;            # fix the /etc/init.d problem
-               next if -d $s;            # skip existing directories
-               print "%dir $s";' "$destdir" >> "$destdir"/_TMP/package.spec
+               next if -d $s and $s !~ m/\Q$ver\E/; # skip existing directories if they do not seem to be versioned
+               print "%dir $s\n";
+             }' \
+         "$destdir" "$FW_PACKAGE_VERSION" >> "$destdir"/_TMP/package.spec
 
     for x in start stop
       do


### PR DESCRIPTION
make-package excludes a directory from the %files list if it already
exists on the host.  Unfortunately, that means that if you are
rebuilding an RPM for an package that is already installed the RPM will
not end up owning its directories.

This change is not the best fix, but it fixes the specific problem we're
having with rebuilding versioned Erlang packages.