### PR TITLE
Fix for dependency closure issue

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+Version 0.9.2
+  * dependency closure was failing if a package provides 2 versions, so now
+  keep track of the second version and have closure check both.
+
 Version 0.9.1
   * set environment variable LC_COLLATE to use a single sort order regardless
     of environment

--- a/fw-pkgin/config
+++ b/fw-pkgin/config
@@ -2,7 +2,7 @@
 # environment variable FW_PACKAGE_DEFAULT_MAINTAINER if non-empty
 
 FW_PACKAGE_NAME="framewerk"
-FW_PACKAGE_VERSION="0.9.1"
+FW_PACKAGE_VERSION="0.9.2"
 FW_PACKAGE_MAINTAINER="Anthony Molinaro <anthonym@alumni.caltech.edu>"
 FW_PACKAGE_SHORT_DESCRIPTION="A extensible development environment."
 FW_PACKAGE_DESCRIPTION=`cat README`

--- a/fw/package/rpm/check-for-packages
+++ b/fw/package/rpm/check-for-packages
@@ -30,10 +30,10 @@ my @packages;
 if ($getdeps eq "yes") {
   my @missings = ();
   my @missing_specs = ();
-  my ($state, undef) = get_state ();
+  my ($state, $virtual) = get_state ();
   # we ignore release in the case we are fetching dependencies, otherwise
   # things stop
-  my $alldeps = parse_depends ($state, $arch, $depends, "no");
+  my $alldeps = parse_depends ($state, $virtual, $arch, $depends, "no");
   @packages = @{$alldeps->{"packages"}};
   @missings = @{$alldeps->{"missing"}};
   @missing_specs = @{$alldeps->{"missing_specs"}};
@@ -82,10 +82,10 @@ if ($getdeps eq "yes") {
   }
 
   if ($num_missings > 0) {
-    ($state, undef) = get_state ();
+    ($state, $virtual) = get_state ();
     # we ignore release in the case we are fetching dependencies, otherwise
     # things stop
-    $alldeps = parse_depends ($state, $arch, $depends, "no");
+    $alldeps = parse_depends ($state, $virtual, $arch, $depends, "no");
     @packages = @{$alldeps->{"packages"}};
     @missings = @{$alldeps->{"missing"}};
     @missing_specs = @{$alldeps->{"missing_specs"}};
@@ -96,8 +96,8 @@ if ($getdeps eq "yes") {
         .join ("\n\t",@missing_specs)."\n";
   }
 } else {
-  my ($state, undef) = get_state ();
-  my $alldeps = parse_depends ($state, $arch, $depends, $release);
+  my ($state, $virtual) = get_state ();
+  my $alldeps = parse_depends ($state, $virtual, $arch, $depends, $release);
   @packages = @{$alldeps->{"packages"}};
 }
 

--- a/fw/package/rpm/dependency-closure
+++ b/fw/package/rpm/dependency-closure
@@ -21,10 +21,10 @@ my $release = $ARGV[2] or die $usage;
 
 my ($state, $virtual) = get_state ();
 
-my $alldeps = parse_depends ($state, $arch, $depends, $release);
+my $alldeps = parse_depends ($state, $virtual, $arch, $depends, $release);
 my @packages = @{$alldeps->{"packages"}};
 
-my @closure = 
+my @closure =
   get_dependencies_closure ($state, $virtual, $arch, $release, @packages);
 
 if (scalar grep { $state->{$_} =~ /-TEST1$/ } @closure)


### PR DESCRIPTION
The issue was around libtool on Centos6 which requires gcc = 4.4.4
```
% rpm -qR libtool | grep gcc
gcc = 4.4.4
```
Gcc does provide this
```
% rpm -q --provides gcc
gcc = 4.4.4-15.el6
gcc = 4.4.6-4.el6
gcc(x86-64) = 4.4.6-4.el6
```
but framewerk was not picking this up.  I found that when the state is calculated there was an extra unused hash called ```$virtual``` which I could repurpose to track the provides version.  Then I could use both the ```$state``` and the ```$virtual``` when checking for dependencies which fulfill the constraint.  This allows the building of C/C++ packages which require libtool (and thus gcc = 4.4.4) to work within framewerk.